### PR TITLE
Add Slice<T> support for azure-spring-data-cosmos

### DIFF
--- a/sdk/cosmos/azure-spring-data-cosmos-test/src/test/java/com/azure/spring/data/cosmos/repository/repository/PageableMemoRepository.java
+++ b/sdk/cosmos/azure-spring-data-cosmos-test/src/test/java/com/azure/spring/data/cosmos/repository/repository/PageableMemoRepository.java
@@ -2,10 +2,14 @@
 // Licensed under the MIT License.
 package com.azure.spring.data.cosmos.repository.repository;
 
+import com.azure.spring.data.cosmos.domain.Importance;
 import com.azure.spring.data.cosmos.domain.PageableMemo;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PageableMemoRepository extends PagingAndSortingRepository<PageableMemo, String> {
+    Slice<PageableMemo> findByImportance(Importance importance, Pageable pageable);
 }

--- a/sdk/cosmos/azure-spring-data-cosmos/src/main/java/com/azure/spring/data/cosmos/core/CosmosOperations.java
+++ b/sdk/cosmos/azure-spring-data-cosmos/src/main/java/com/azure/spring/data/cosmos/core/CosmosOperations.java
@@ -11,6 +11,7 @@ import com.azure.spring.data.cosmos.core.query.CosmosQuery;
 import com.azure.spring.data.cosmos.repository.support.CosmosEntityInformation;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 
 /**
@@ -268,6 +269,17 @@ public interface CosmosOperations {
      * @return results as Page
      */
     <T> Page<T> paginationQuery(CosmosQuery query, Class<T> domainType, String containerName);
+
+    /**
+     * Slice query
+     *
+     * @param query the document query
+     * @param domainType type class
+     * @param containerName the container name
+     * @param <T> type class of domainType
+     * @return results as Slice
+     */
+    <T> Slice<T> sliceQuery(CosmosQuery query, Class<T> domainType, String containerName);
 
     /**
      * Count

--- a/sdk/cosmos/azure-spring-data-cosmos/src/main/java/com/azure/spring/data/cosmos/core/query/CosmosSliceImpl.java
+++ b/sdk/cosmos/azure-spring-data-cosmos/src/main/java/com/azure/spring/data/cosmos/core/query/CosmosSliceImpl.java
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.azure.spring.data.cosmos.core.query;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@code CosmosSliceImpl} implementation.
+ *
+ * @param <T> the type of which the CosmosSliceImpl consists.
+ */
+public class CosmosSliceImpl<T> extends SliceImpl<T> {
+
+    private static final long serialVersionUID = 4487077496284030775L;
+
+    //  For any query, CosmosDB returns documents less than or equal to page size
+    //  Depending on the number of RUs, the number of returned documents can change
+    //  Storing the offset of current page, helps to check hasNext and next values
+    private final long offset;
+
+    /**
+     * Constructor of {@code CosmosSliceImpl}.
+     *
+     * @param content the content of this page, must not be {@literal null}.
+     * @param pageable the paging information, must not be {@literal null}.
+     * @param hasNext whether the query has any more results to fetch
+     */
+    public CosmosSliceImpl(List<T> content, Pageable pageable, boolean hasNext) {
+        super(content, pageable, hasNext);
+        this.offset = pageable.getOffset();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        final CosmosSliceImpl<?> that = (CosmosSliceImpl<?>) o;
+        return offset == that.offset;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), offset);
+    }
+}

--- a/sdk/cosmos/azure-spring-data-cosmos/src/main/java/com/azure/spring/data/cosmos/repository/query/AbstractCosmosQuery.java
+++ b/sdk/cosmos/azure-spring-data-cosmos/src/main/java/com/azure/spring/data/cosmos/repository/query/AbstractCosmosQuery.java
@@ -59,6 +59,8 @@ public abstract class AbstractCosmosQuery implements RepositoryQuery {
             return new CosmosQueryExecution.DeleteExecution(operations);
         } else if (isPageQuery()) {
             return new CosmosQueryExecution.PagedExecution(operations, accessor.getPageable());
+        } else if (isSliceQuery()) {
+            return new CosmosQueryExecution.SliceExecution(operations, accessor.getPageable());
         } else if (isExistsQuery()) {
             return new CosmosQueryExecution.ExistsExecution(operations);
         } else if (isCollectionQuery()) {
@@ -90,5 +92,7 @@ public abstract class AbstractCosmosQuery implements RepositoryQuery {
     protected boolean isCollectionQuery() {
         return method.isCollectionQuery();
     }
+
+    protected boolean isSliceQuery() { return method.isSliceQuery(); }
 
 }

--- a/sdk/cosmos/azure-spring-data-cosmos/src/main/java/com/azure/spring/data/cosmos/repository/query/CosmosQueryExecution.java
+++ b/sdk/cosmos/azure-spring-data-cosmos/src/main/java/com/azure/spring/data/cosmos/repository/query/CosmosQueryExecution.java
@@ -160,4 +160,30 @@ public interface CosmosQueryExecution {
             return operations.paginationQuery(query, type, container);
         }
     }
+
+    /**
+     * sliceQuery operation implementation to execute a sliceQuery query
+     */
+    final class SliceExecution implements CosmosQueryExecution {
+        private final CosmosOperations operations;
+        private final Pageable pageable;
+
+        public SliceExecution(CosmosOperations operations, Pageable pageable) {
+            this.operations = operations;
+            this.pageable = pageable;
+        }
+
+        @Override
+        public Object execute(CosmosQuery query, Class<?> type, String container) {
+            if (pageable.getPageNumber() != 0
+                && !(pageable instanceof CosmosPageRequest)) {
+                throw new IllegalStateException("Not the first page but Pageable is not a valid "
+                    + "CosmosPageRequest, requestContinuation is required for non first page request");
+            }
+
+            query.with(pageable);
+
+            return operations.sliceQuery(query, type, container);
+        }
+    }
 }

--- a/sdk/cosmos/azure-spring-data-cosmos/src/test/java/com/azure/spring/data/cosmos/repository/query/AbstractCosmosQueryUnitTest.java
+++ b/sdk/cosmos/azure-spring-data-cosmos/src/test/java/com/azure/spring/data/cosmos/repository/query/AbstractCosmosQueryUnitTest.java
@@ -3,6 +3,7 @@
 package com.azure.spring.data.cosmos.repository.query;
 
 import com.azure.spring.data.cosmos.core.CosmosOperations;
+import com.azure.spring.data.cosmos.core.query.CosmosPageRequest;
 import com.azure.spring.data.cosmos.core.query.CosmosQuery;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,6 +19,9 @@ public class AbstractCosmosQueryUnitTest {
     @Mock
     CosmosQueryMethod method;
 
+    @Mock
+    CosmosParameterAccessor accessor;
+
     @Test
     public void testShouldUseMultiEntityExecutionIfMethodIsCollectionQuery() {
         when(method.isCollectionQuery()).thenReturn(true);
@@ -32,6 +36,15 @@ public class AbstractCosmosQueryUnitTest {
         TestCosmosQuery cosmosQuery = new TestCosmosQuery(method, null);
         CosmosQueryExecution execution = cosmosQuery.getExecution(null, null);
         Assert.isInstanceOf(CosmosQueryExecution.SingleEntityExecution.class, execution);
+    }
+
+    @Test
+    public void testShouldUseSliceExecutionIfMethodIsSliceQuery() {
+        when(method.isSliceQuery()).thenReturn(true);
+        when(accessor.getPageable()).thenReturn(CosmosPageRequest.of(0, 10));
+        TestCosmosQuery cosmosQuery = new TestCosmosQuery(method, null);
+        CosmosQueryExecution execution = cosmosQuery.getExecution(accessor, null);
+        Assert.isInstanceOf(CosmosQueryExecution.SliceExecution.class, execution);
     }
 
     private class TestCosmosQuery extends AbstractCosmosQuery {


### PR DESCRIPTION
Add Slice<T> support for queries that do not require page count. Avoids running the count query, which can be expensive.

Resolves #20950